### PR TITLE
reduce calls to cloned in Graph::edges

### DIFF
--- a/dot_gen/src/graph/graph_walk.rs
+++ b/dot_gen/src/graph/graph_walk.rs
@@ -11,15 +11,12 @@ impl<'a> dot::GraphWalk<'a, Node<'a>, Edge> for Graph<'a> {
         Cow::Owned(
             self.0
                 .keys()
-                .cloned()
                 .enumerate()
                 .flat_map(|(i, from)| {
                     self.0
                         .keys()
                         .skip(i + 1)
-                        .cloned()
-                        .map(|to| (from, to))
-                        .collect::<Vec<_>>()
+                        .map(move |to| (*from, *to))
                 })
                 .collect(),
         )


### PR DESCRIPTION
Note that the `&usize`s are still getting copied (i think), it just happens during dereferencing now.
Also gets rid of the `.collect::<Vec<_>>()` call.